### PR TITLE
Bugfix: Use of BufReader causes occasional data loss

### DIFF
--- a/src/v5.rs
+++ b/src/v5.rs
@@ -1,6 +1,6 @@
 use byteorder::{ReadBytesExt, WriteBytesExt, BigEndian};
 use std::cmp;
-use std::io::{self, Read, Write, BufReader};
+use std::io::{self, Read, Write};
 use std::net::{SocketAddr, ToSocketAddrs, SocketAddrV4, SocketAddrV6, TcpStream, Ipv4Addr,
                Ipv6Addr, UdpSocket};
 use std::ptr;
@@ -38,7 +38,6 @@ fn read_addr<R: Read>(socket: &mut R) -> io::Result<TargetAddr> {
 }
 
 fn read_response(socket: &mut TcpStream) -> io::Result<TargetAddr> {
-    let mut socket = BufReader::with_capacity(MAX_ADDR_LEN + 3, socket);
 
     if socket.read_u8()? != 5 {
         return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid response version"));
@@ -61,7 +60,7 @@ fn read_response(socket: &mut TcpStream) -> io::Result<TargetAddr> {
         return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid reserved byte"));
     }
 
-    read_addr(&mut socket)
+    read_addr(socket)
 }
 
 fn write_addr(mut packet: &mut [u8], target: &TargetAddr) -> io::Result<usize> {


### PR DESCRIPTION
Thanks for the library! 

I noticed that I was occasionally failing to receive the correct data via read_exact() despite packet traces demonstrating that the data was on the wire (for clarity, this didn't surface as an error, but in incorrect data)

Looking through the packet traces, the failures happened when the SOCKS5 Address Info arrived the same TCP packet as the initial data from the remote server.

I believe in this instance that the initial data from the remote was being hijacked by the BufReader being used in read_response() function. Removing the BufReader resolved the sporadic failures. 

More generally, as implemented, the BufReader will read an arbitrary amount of data from the socket, and then be dropped out of scope - taking whatever data it has consumed (whether related to the SOCKS proxy or the remote server) with it. This PR removes BufReader from the flow entirely.